### PR TITLE
Fix bug for this code

### DIFF
--- a/payment_code.php
+++ b/payment_code.php
@@ -3,7 +3,6 @@ add_action( 'woocommerce_payment_complete', 'so_payment_complete' );
 function so_payment_complete($order_id){
     
     $order = wc_get_order($order_id);
-    echo "Hello world";
      if(!empty($order)){
          $user = $order->get_user();
                       $order_det=array();


### PR DESCRIPTION
Remove an unintended debug output from `payment_code.php` to prevent unsolicited text and potential header/output issues during WooCommerce's `payment_complete` hook.

---
<a href="https://cursor.com/background-agent?bcId=bc-f571ace1-37ed-4343-8cb4-b9b8e8e0e4be">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f571ace1-37ed-4343-8cb4-b9b8e8e0e4be">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

